### PR TITLE
Install script hardening and enhancements

### DIFF
--- a/basic-install.sh
+++ b/basic-install.sh
@@ -23,7 +23,6 @@ echo '@audio - nice -20' >> /etc/security/limits.conf
 
 border 'Improving Network Latency'
 
-[[ -f /etc/sysctl.d/network-latency.conf ]] && mv /etc/sysctl.d/network-latency.conf /etc/sysctl.d/network-latency.conf.bak
 echo "#New Network Latency" > /etc/sysctl.d/network-latency.conf
 echo 'net.core.rmem_max = 16777216' >> /etc/sysctl.d/network-latency.conf
 echo 'net.core.wmem_max = 16777216' >> /etc/sysctl.d/network-latency.conf

--- a/basic-install.sh
+++ b/basic-install.sh
@@ -1,81 +1,40 @@
 #!/bin/bash
+
 border()
 {
-    title="| $1 |"
-    edge=$(echo "$title" | sed 's/./-/g')
-    echo "$edge"
-    echo "$title"
-    echo "$edge"
+    local title="| $1 |"
+    local edge=${title//?/-}
+    echo -e "${edge}\n${title}\n${edge}"
+    sleep 4
 }
 
-border "Downloading Sound File"
+border 'Downloading Sound File'
 
-sleep 4
-wget https://github.com/dynobot/Linux-Audio-Adjustments/raw/master/Sound.sh
-mv Sound.sh /usr/bin/Sound.sh
+wget https://github.com/dynobot/Linux-Audio-Adjustments/raw/master/Sound.sh -O /usr/bin/Sound.sh
 chmod 755 /usr/bin/Sound.sh
-sleep 4
 
-border()
-{
-    title="| $1 |"
-    edge=$(echo "$title" | sed 's/./-/g')
-    echo "$edge"
-    echo "$title"
-    echo "$edge"
-}
+border 'Increasing Sound Group Priority'
 
-border "Increasing Sound Group Priority"
-sleep 4
-mv /etc/security/limits.conf /etc/security/limits.conf.bak
-echo "#New Limits" > /etc/security/limits.conf
+[[ -f /etc/security/limits.conf ]] && mv /etc/security/limits.conf /etc/security/limits.conf.bak
+echo '#New Limits' > /etc/security/limits.conf
 echo '@audio - rtprio 99' >> /etc/security/limits.conf
 echo '@audio - memlock 512000' >> /etc/security/limits.conf
 echo '@audio - nice -20' >> /etc/security/limits.conf
-sleep 5
 
-border()
-{
-    title="| $1 |"
-    edge=$(echo "$title" | sed 's/./-/g')
-    echo "$edge"
-    echo "$title"
-    echo "$edge"
-}
+border 'Improving Network Latency'
 
-border "Improving Network Latency"
+[[ -f /etc/sysctl.d/network-latency.conf ]] && mv /etc/sysctl.d/network-latency.conf /etc/sysctl.d/network-latency.conf.bak
+echo "#New Network Latency" > /etc/sysctl.d/network-latency.conf
+echo 'net.core.rmem_max = 16777216' >> /etc/sysctl.d/network-latency.conf
+echo 'net.core.wmem_max = 16777216' >> /etc/sysctl.d/network-latency.conf
 
+border 'Creating System Service'
 
-mv /etc/sysctl.conf /etc/sysctl.conf.bak
-echo "#New Network Latency" > /etc/sysctl.conf
-echo 'net.core.rmem_max = 16777216' >> /etc/sysctl.conf
-echo 'net.core.wmem_max = 16777216' >> /etc/sysctl.conf
-sleep 4
+[[ -f /etc/rc.local ]] || echo -e '#/bin/bash\n\nexit 0' > /etc/rc.local
+grep -q '/usr/bin/Sound.sh' /etc/rc.local || sed -i '\|^#!/bin/.*sh|a\/usr/bin/Sound.sh' /etc/rc.local
+chmod +x /etc/rc.local
+systemctl enable rc-local || systemctl enable rc.local
 
-border()
-{
-    title="| $1 |"
-    edge=$(echo "$title" | sed 's/./-/g')
-    echo "$edge"
-    echo "$title"
-    echo "$edge"
-}
+border 'Rebooting System'
 
-border "Creating System Service"
-
-
-sleep 4
-sed -i -e '$i \/usr/bin/Sound.sh\n' /etc/rc.local
-
-sleep 4
-border()
-{
-    title="| $1 |"
-    edge=$(echo "$title" | sed 's/./-/g')
-    echo "$edge"
-    echo "$title"
-    echo "$edge"
-}
-
-border "Rebooting System"
 reboot

--- a/remove.sh
+++ b/remove.sh
@@ -1,33 +1,20 @@
 #!/bin/bash
+
 border()
 {
-    title="| $1 |"
-    edge=$(echo "$title" | sed 's/./-/g')
-    echo "$edge"
-    echo "$title"
-    echo "$edge"
+    local title="| $1 |"
+    local edge=${title//?/-}
+    echo -e "${edge}\n${title}\n${edge}"
+    sleep 4
 }
 
-border "Removing Linux Audio Tuning"
+border 'Removing Linux Audio Tuning'
 
-rm /usr/bin/Sound.sh
-rm /etc/security/limits.conf
-mv /etc/security/limits.conf.bak /etc/security/limits.conf
-rm /etc/sysctl.conf
-sed -i '/usr/d' /etc/rc.local
+[[ -f /usr/bin/Sound.sh ]] && rm /usr/bin/Sound.sh
+[[ -f /etc/sysctl.d/network-latency.conf ]] && rm /etc/sysctl.d/network-latency.conf
+[[ -f /etc/security/limits.conf.bak ]] && mv /etc/security/limits.conf.bak /etc/security/limits.conf
+[[ -f /etc/rc.local ]] && sed -i '\|/usr/bin/Sound.sh|d' /etc/rc.local
 
-mv /etc/sysctl.conf.bak /etc/sysctl.conf
-
-sleep 4
-border()
-{
-    title="| $1 |"
-    edge=$(echo "$title" | sed 's/./-/g')
-    echo "$edge"
-    echo "$title"
-    echo "$edge"
-}
-
-border "Rebooting System"
+border 'Rebooting System'
 
 reboot


### PR DESCRIPTION
#### Install script
+ Coding: Declare `border()` function only once
+ Coding: Add `sleep` to `border()` function to have if done between every step automatically
+ Hardening: Check for existing files before attempting backup, to avoid error messages
+ Compatibility: Create own `/etc/sysctl.d/` config file instead of writing to `/etc/sysctl.conf`, which also renders the backup obsolete
+ Hardening: Check for `rc.local` existence, before attempting to add line, otherwise pre-create it.
+ Compatibility: Add `/usr/bin/Sound.sh` call to start of `rc.local` (after shebang) instead of end, since `rc.local` requires an `exit 0` before ending, which usually is located before the last empty line, so `Sound.sh` would not be called.
+ Compatibility: In case `rc.local` functionality is not enabled, make it executable and enable the related compatibility systemd unit(s).

#### Uninstall script
+ Coding: Declare `border()` function only once
+ Coding: Add sleep to `border()` function to have if done between every step automatically
+ Hardening: Check for file existence before attempting removal and moving, to avoid error messages
+ Hardening: Do not remove `/etc/security/limits.conf`, in case backup got removed, instead only overwrite with backup, if it exists
+ Hardening: Remove `Sound.sh` call from `rc.local` more specifically, to not accidentally remove unwanted lines
+ Compatibility: Remove `/etc/sysctl.d/network-latency.conf` according to install script change